### PR TITLE
Adding retries to AWS API calls

### DIFF
--- a/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
+++ b/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
@@ -17,6 +17,9 @@
 -define(INSTANCE_AZ, "placement/availability-zone").
 -define(INSTANCE_HOST, "169.254.169.254").
 
+-define(LINEAR_BACK_OFF_MILLIS, 1000).
+-define(MAX_RETRIES, 30).
+
 % rabbitmq/rabbitmq-peer-discovery-aws#25
 
 % Note: this timeout must not be greater than the default


### PR DESCRIPTION
## Proposed Changes

This is a test commit for a RabbitMQ open source contribution workshop. 

Since 3.8.18, RabbitMQ AWS peer discovery mechanism no longer uses randomized delays to avoid the inherent race condition during initial cluster formation. Instead it relies on an internal distributed locking mechanism available in modern Erlang releases (23.2 and newer). When transient networking issue happens, cluster formation will stuck at locking/unlocking process for a long time. This commit is to add retry logic in AWS API calls to mitigate the impact of transient networking failures.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
